### PR TITLE
Support order enum and use it by orderBy()

### DIFF
--- a/src/main/java/me/geso/tinyorm/AbstractSelectStatement.java
+++ b/src/main/java/me/geso/tinyorm/AbstractSelectStatement.java
@@ -57,6 +57,13 @@ public abstract class AbstractSelectStatement<T, Impl> {
 	}
 
 	@SuppressWarnings("unchecked")
+	public Impl orderBy(String key, Order order) {
+		this.orderBy.add(new StringBuilder(key).append(" ")
+				.append(order.toString()).toString());
+		return (Impl) this;
+	}
+
+	@SuppressWarnings("unchecked")
 	public Impl forUpdate() {
 		this.forUpdate = true;
 		return (Impl) this;

--- a/src/main/java/me/geso/tinyorm/Order.java
+++ b/src/main/java/me/geso/tinyorm/Order.java
@@ -1,0 +1,5 @@
+package me.geso.tinyorm;
+
+public enum Order {
+	ASC, DESC,
+}

--- a/src/test/java/me/geso/tinyorm/TinyORMTest.java
+++ b/src/test/java/me/geso/tinyorm/TinyORMTest.java
@@ -246,6 +246,44 @@ public class TinyORMTest extends TestBase {
 		assertEquals(got.get(1).getName(), "m1");
 	}
 
+	@SuppressWarnings("unused")
+	@Test
+	public void searchWithStmtAndDescOrder() {
+		Member member1 = this.orm.insert(Member.class).value("name", "m1")
+			.executeSelect();
+		Member member2 = this.orm.insert(Member.class).value("name", "m2")
+			.executeSelect();
+		Member member3 = this.orm.insert(Member.class).value("name", "b1")
+			.executeSelect();
+
+		List<Member> got = this.orm.search(Member.class)
+			.where("name LIKE ?", "m%")
+			.orderBy("id", Order.DESC)
+			.execute();
+		assertEquals(got.size(), 2);
+		assertEquals(got.get(0).getName(), "m2");
+		assertEquals(got.get(1).getName(), "m1");
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void searchWithStmtAndAscOrder() {
+		Member member1 = this.orm.insert(Member.class).value("name", "m1")
+			.executeSelect();
+		Member member2 = this.orm.insert(Member.class).value("name", "m2")
+			.executeSelect();
+		Member member3 = this.orm.insert(Member.class).value("name", "b1")
+			.executeSelect();
+
+		List<Member> got = this.orm.search(Member.class)
+			.where("name LIKE ?", "m%")
+			.orderBy("id", Order.ASC)
+			.execute();
+		assertEquals(got.size(), 2);
+		assertEquals(got.get(0).getName(), "m1");
+		assertEquals(got.get(1).getName(), "m2");
+	}
+
 	@Test
 	public void testMapRowsFromResultSet() throws SQLException {
 		this.orm.getConnection()


### PR DESCRIPTION
Now argument of `orderBy(String orderBy)` is able to specify freedom, so it cannot detect SQL syntax error which is caused by order clause when compiling.
Accordingly support order clause by enum and ensure the correctness of SQL syntax on compiling phase.

How do you think about this feature?