### PR TITLE
Support transaction mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
 			<artifactId>jdbcutils</artifactId>
 			<version>1.0.0</version>
 		</dependency>
+		<dependency>
+			<groupId>net.moznion</groupId>
+			<artifactId>db-transaction-manager</artifactId>
+			<version>1.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 		<dependency>
 			<groupId>net.moznion</groupId>
 			<artifactId>db-transaction-manager</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>me.geso</groupId>
@@ -18,17 +19,17 @@
 		<url>https://github.com/tokuhirom/tinyorm/</url>
 		<connection>scm:git:git://github.com/tokuhirom/tinyorm.git</connection>
 		<developerConnection>scm:git:git@github.com:tokuhirom/tinyorm.git</developerConnection>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 
-    <developers>
-        <developer>
-            <id>tokuhirom</id>
-            <name>Tokuhiro Matsuno</name>
-            <email>tokuhirom@gmail.com</email>
-            <url>https://twitter.com/tokuhirom</url>
-        </developer>
-		</developers>
+	<developers>
+		<developer>
+			<id>tokuhirom</id>
+			<name>Tokuhiro Matsuno</name>
+			<email>tokuhirom@gmail.com</email>
+			<url>https://twitter.com/tokuhirom</url>
+		</developer>
+	</developers>
 
 	<licenses>
 		<license>
@@ -38,16 +39,16 @@
 		</license>
 	</licenses>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
+	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
+	</distributionManagement>
 
 	<dependencies>
 		<dependency>
@@ -114,45 +115,45 @@
 	</dependencies>
 
 	<build>
-			<plugins>
-				<plugin>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.1</version>
-					<configuration>
-						<source>1.8</source>
-						<target>1.8</target>
-						<encoding>UTF-8</encoding>
-            <compilerArguments>
-              <parameters />
-							<Werror />
-            </compilerArguments>
-					</configuration>
-				</plugin>
+		<plugins>
 			<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-source-plugin</artifactId>
-					<version>2.3</version>
-					<executions>
-							<execution>
-									<id>attach-sources</id>
-									<goals>
-											<goal>jar</goal>
-									</goals>
-							</execution>
-					</executions>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<encoding>UTF-8</encoding>
+					<compilerArguments>
+						<parameters />
+						<Werror />
+					</compilerArguments>
+				</configuration>
 			</plugin>
 			<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.9.1</version>
-					<executions>
-							<execution>
-									<id>attach-javadocs</id>
-									<goals>
-											<goal>jar</goal>
-									</goals>
-							</execution>
-					</executions>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.3</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.9.1</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -161,41 +162,41 @@
 				<configuration>
 					<systemPropertyVariables>
 						<propertyName>org.slf4j.simpleLogger.defaultLogLevel</propertyName>
-			 			<buildDirectory>debug</buildDirectory>
+						<buildDirectory>debug</buildDirectory>
 					</systemPropertyVariables>
 				</configuration>
 			</plugin>
 			<plugin>
-					<groupId>org.sonatype.plugins</groupId>
-					<artifactId>nexus-staging-maven-plugin</artifactId>
-					<version>1.6.3</version>
-					<extensions>true</extensions>
-					<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
-					</configuration>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>1.6.3</version>
+				<extensions>true</extensions>
+				<configuration>
+					<serverId>ossrh</serverId>
+					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+					<autoReleaseAfterClose>true</autoReleaseAfterClose>
+				</configuration>
 			</plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.1</version>
-      </plugin>
 			<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-gpg-plugin</artifactId>
-					<version>1.5</version>
-					<executions>
-							<execution>
-									<id>sign-artifacts</id>
-									<phase>verify</phase>
-									<goals>
-											<goal>sign</goal>
-									</goals>
-							</execution>
-					</executions>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.5.1</version>
 			</plugin>
-			</plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.5</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 	<reporting>
 		<plugins>

--- a/src/main/java/me/geso/tinyorm/TinyORM.java
+++ b/src/main/java/me/geso/tinyorm/TinyORM.java
@@ -518,6 +518,11 @@ public class TinyORM {
 	/**
 	 * Begins transaction.
 	 * 
+	 * <p>
+	 * This method backups automatically the status of auto commit mode when
+	 * this is called. The status will be turned back when transaction is end.
+	 * </p>
+	 * 
 	 * @throws SQLException
 	 */
 	public void transactionBegin() throws SQLException {
@@ -535,20 +540,18 @@ public class TinyORM {
 	/**
 	 * Executes statements within a transaction.
 	 * 
-	 * <p>
-	 * For example;
-	 * 
 	 * <pre>
-	 * <code>
+	 * {@code
 	 * db.transactionScope(() -> {
 	 *     db.insert(Member.class)
 	 * 	       .value("name", "John")
 	 * 	       .execute();
 	 *     db.transactionCommit();
 	 * });
-	 * </code>
+	 * }
 	 * </pre>
 	 * 
+	 * <p>
 	 * If it escapes from try-with-resource statement without any action
 	 * ({@code transactionCommit()} or {@code transactionRollback()}),
 	 * transaction will rollback automatically.

--- a/src/main/java/me/geso/tinyorm/TinyORM.java
+++ b/src/main/java/me/geso/tinyorm/TinyORM.java
@@ -530,24 +530,16 @@ public class TinyORM {
 	}
 
 	/**
-	 * Runnable interface for statement which is throwable SQLException.
-	 */
-	@FunctionalInterface
-	public interface RunnableStatement {
-		public void run() throws SQLException;
-	}
-
-	/**
-	 * Executes statements within a transaction.
+	 * Dispense a new transaction scope.
 	 * 
 	 * <pre>
 	 * {@code
-	 * db.transactionScope(() -> {
+	 * try (TransactionScope txn = db.createTransactionScope()) {
 	 *     db.insert(Member.class)
 	 * 	       .value("name", "John")
 	 * 	       .execute();
 	 *     db.transactionCommit();
-	 * });
+	 * }
 	 * }
 	 * </pre>
 	 * 
@@ -557,14 +549,10 @@ public class TinyORM {
 	 * transaction will rollback automatically.
 	 * </p>
 	 * 
-	 * @param statements
 	 * @throws SQLException
 	 */
-	public void transactionScope(RunnableStatement statements)
-			throws SQLException {
-		try (TransactionScope txn = new TransactionScope(transactionManager)) {
-			statements.run();
-		}
+	public TransactionScope createTransactionScope() throws SQLException {
+		return new TransactionScope(transactionManager);
 	}
 
 	/**

--- a/src/test/java/me/geso/tinyorm/TransactionTest.java
+++ b/src/test/java/me/geso/tinyorm/TransactionTest.java
@@ -2,9 +2,10 @@ package me.geso.tinyorm;
 
 import static org.junit.Assert.assertEquals;
 
+import net.moznion.db.transaction.manager.TransactionScope;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import me.geso.tinyorm.annotations.PrimaryKey;
 import me.geso.tinyorm.annotations.Table;
 
@@ -52,20 +53,20 @@ public class TransactionTest extends TestBase {
 
 	@Test
 	public void transactionCommitWithScopeSuccessfully() throws SQLException {
-		orm.transactionScope(() -> {
+		try (TransactionScope txn = orm.createTransactionScope()) {
 			orm.insert(X.class).value("a", "hoge").execute();
 			orm.transactionCommit();
-		});
+		}
 		Optional<X> row = orm.single(X.class).where("a=?", "hoge").execute();
 		assertEquals(row.get().getA(), "hoge");
 	}
 
 	@Test
 	public void transactionRollbackWithScopeSuccessfully() throws SQLException {
-		orm.transactionScope(() -> {
+		try (TransactionScope txn = orm.createTransactionScope()) {
 			orm.insert(X.class).value("a", "hoge").execute();
 			orm.transactionRollback();
-		});
+		}
 		Optional<X> row = orm.single(X.class).where("a=?", "hoge").execute();
 		assertEquals(row.isPresent(), false);
 	}
@@ -73,9 +74,9 @@ public class TransactionTest extends TestBase {
 	@Test
 	public void transactionImplicitRollbackWithScopeSuccessfully()
 			throws SQLException {
-		orm.transactionScope(() -> {
+		try (TransactionScope txn = orm.createTransactionScope()) {
 			orm.insert(X.class).value("a", "hoge").execute();
-		});
+		}
 		Optional<X> row = orm.single(X.class).where("a=?", "hoge").execute();
 		assertEquals(row.isPresent(), false);
 	}

--- a/src/test/java/me/geso/tinyorm/TransactionTest.java
+++ b/src/test/java/me/geso/tinyorm/TransactionTest.java
@@ -1,0 +1,90 @@
+package me.geso.tinyorm;
+
+import static org.junit.Assert.assertEquals;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import me.geso.tinyorm.annotations.PrimaryKey;
+import me.geso.tinyorm.annotations.Table;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+public class TransactionTest extends TestBase {
+	@Before
+	public void before() throws SQLException {
+		orm.setAutoCommit(true);
+		orm.getConnection().prepareStatement("DROP TABLE IF EXISTS x")
+				.executeUpdate();
+		orm.getConnection()
+				.prepareStatement(
+						"CREATE TABLE x (a VARCHAR(255) NOT NULL, n int default 0, PRIMARY KEY (a))")
+				.executeUpdate();
+	}
+
+	@Test
+	public void setAutocommitSuccessfully() throws SQLException {
+		orm.setAutoCommit(false);
+		assertEquals(false, orm.getConnection().getAutoCommit());
+	}
+
+	@Test
+	public void transactionCommitSuccessfully() throws SQLException {
+		orm.transactionBegin();
+		orm.insert(X.class).value("a", "hoge").execute();
+		orm.transactionCommit();
+		Optional<X> row = orm.single(X.class).where("a=?", "hoge").execute();
+		assertEquals(row.get().getA(), "hoge");
+	}
+
+	@Test
+	public void transactionRollbackSuccessfully() throws SQLException {
+		orm.transactionBegin();
+		orm.insert(X.class).value("a", "hoge").execute();
+		orm.transactionRollback();
+		Optional<X> row = orm.single(X.class).where("a=?", "hoge").execute();
+		assertEquals(row.isPresent(), false);
+	}
+
+	@Test
+	public void transactionCommitWithScopeSuccessfully() throws SQLException {
+		orm.transactionScope(() -> {
+			orm.insert(X.class).value("a", "hoge").execute();
+			orm.transactionCommit();
+		});
+		Optional<X> row = orm.single(X.class).where("a=?", "hoge").execute();
+		assertEquals(row.get().getA(), "hoge");
+	}
+
+	@Test
+	public void transactionRollbackWithScopeSuccessfully() throws SQLException {
+		orm.transactionScope(() -> {
+			orm.insert(X.class).value("a", "hoge").execute();
+			orm.transactionRollback();
+		});
+		Optional<X> row = orm.single(X.class).where("a=?", "hoge").execute();
+		assertEquals(row.isPresent(), false);
+	}
+
+	@Test
+	public void transactionImplicitRollbackWithScopeSuccessfully()
+			throws SQLException {
+		orm.transactionScope(() -> {
+			orm.insert(X.class).value("a", "hoge").execute();
+		});
+		Optional<X> row = orm.single(X.class).where("a=?", "hoge").execute();
+		assertEquals(row.isPresent(), false);
+	}
+
+	@Table("x")
+	@Data
+	@EqualsAndHashCode(callSuper = false)
+	public static class X extends Row<X> {
+		@PrimaryKey
+		private String a;
+	}
+}


### PR DESCRIPTION
ref #6 

This pull-request contains following changes.

## Supports following methods;

- `setAutoCommit(boolean isAutoCommit)`: Sets auto-commit mode to connection which is held by an instance of ORM
- `transactionBegin()`: Begins transaction with saving original auto-commit mode
- `transactionCommit()`: Commits the current transaction.
- `transactionRollback()`: Rollbacks the current transaction.
- `createTransactionScope()`: Dispense a transaction scope instance.

## <s>Provides a functional interface;</s>

- <s>`RunnableStatement`: Runnable interface for statement (this interface's method can throw SQLException). For `transactionScope`.</s>