### PR TITLE
Added multiple call support for `InsertStatement#onDuplicateKeyUpdate()`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ Create new database object.
       .value("name", "John")
       .execute();
 
+This statement generate following query:
+
+    INSERT INTO member (name) VALUES ('John')
+
+If you want to use `ON DUPLICATE KEY UPDATE`, you can call `InsertStatement#onDuplicateKeyUpdate` method.
+
+For example:
+
+			orm.insert(Member.class)
+        .value("email", email)
+        .value("name", name)
+				.onDuplicateKeyUpdate("name=?", name)
+				.execute();
+    
+
 ### Insert row with form class.
 
     @Data // lombok

--- a/tinyorm/src/test/java/me/geso/tinyorm/InsertStatementTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/InsertStatementTest.java
@@ -21,6 +21,7 @@ public class InsertStatementTest extends TestBase {
 		createTable("x",
 			"a VARCHAR(255) NOT NULL",
 			"n int default 0",
+			"m int default 0",
 			"PRIMARY KEY (a)");
 	}
 
@@ -29,26 +30,32 @@ public class InsertStatementTest extends TestBase {
 		{
 			assertThat(orm.insert(X.class).value("a", "hoge")
 				.onDuplicateKeyUpdate("n=n+1")
+				.onDuplicateKeyUpdate("m=m+2")
 				.execute(), is(1));
 			Optional<X> row = orm.single(X.class).where("a=?", "hoge")
 				.execute();
 			assertThat(row.get().getN(), is(0));
+			assertThat(row.get().getM(), is(0));
 		}
 		{
 			assertThat(orm.insert(X.class).value("a", "hoge")
 				.onDuplicateKeyUpdate("n=n+1")
+				.onDuplicateKeyUpdate("m=m+2")
 				.execute(), is(2));
 			Optional<X> row = orm.single(X.class).where("a=?", "hoge")
 				.execute();
 			assertThat(row.get().getN(), is(1));
+			assertThat(row.get().getM(), is(2));
 		}
 		{
 			assertThat(orm.insert(X.class).value("a", "hoge")
 				.onDuplicateKeyUpdate("n=n+1")
+				.onDuplicateKeyUpdate("m=m+?", 8)
 				.execute(), is(2));
 			Optional<X> row = orm.single(X.class).where("a=?", "hoge")
 				.execute();
 			assertThat(row.get().getN(), is(2));
+			assertThat(row.get().getM(), is(10));
 		}
 	}
 
@@ -60,5 +67,7 @@ public class InsertStatementTest extends TestBase {
 		private String a;
 		@Column
 		private int n;
+		@Column
+		private int m;
 	}
 }


### PR DESCRIPTION
In current version, `InsertStatement#onDuplicateKeyUpdate()` has only
one slot for `on duplicate key update` clause.

This behaviour is horrible. It should be appendable.

i.e. in following case with current version, `n=n+1` will omit in the query.

    orm.insert(X.class)
            .value("a", "hoge")
            .onDuplicateKeyUpdate("n=n+1") // omit this.
            .onDuplicateKeyUpdate("m=m+2")
            .execute()
    // =>
    //   INSERT INTO x (a) VALUES (hoge) ON DUPLICATE KEY UPDATE
    //                     m=m+2

This commit makes the query as following.

    INSERT INTO x (a) VALUES (hoge)
        ON DUPLICATE KEY UPDATE n=n+1, m=m+2