### PR TITLE
Append `LIMIT 1` clause to generated SQL on single()

### DIFF
--- a/tinyorm/src/main/java/me/geso/tinyorm/TinyORM.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/TinyORM.java
@@ -130,8 +130,13 @@ public class TinyORM implements Closeable {
 	 */
 	public <T extends Row<?>> BeanSelectStatement<T> single(Class<T> klass) {
 		TableMeta<T> tableMeta = this.getTableMeta(klass);
-		return new BeanSelectStatement<>(this.getConnection(),
-			klass, tableMeta, this);
+		BeanSelectStatement<T> statement =  new BeanSelectStatement<>(
+			this.getConnection(), klass, tableMeta, this);
+
+		// ensure at most single result for single(). (as default behavior)
+		statement.limit(1);
+		
+		return statement;
 	}
 
 	/**

--- a/tinyorm/src/test/java/me/geso/tinyorm/AbstractSelectStatementTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/AbstractSelectStatementTest.java
@@ -48,7 +48,7 @@ public class AbstractSelectStatementTest extends TestBase {
 
 	@Test
 	public void testLimit() {
-		assertThat(this.orm.single(Member.class)
+		assertThat(this.orm.search(Member.class)
 			.limit(10).buildQuery().getSQL(),
 			is("SELECT * FROM `member` LIMIT 10"));
 	}

--- a/tinyorm/src/test/java/me/geso/tinyorm/AbstractSelectStatementTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/AbstractSelectStatementTest.java
@@ -30,25 +30,30 @@ public class AbstractSelectStatementTest extends TestBase {
 	@Test
 	public void singleForUpdate() throws SQLException, RichSQLException {
 		assertThat(this.orm.single(Member.class).buildQuery().getSQL(),
-			is("SELECT * FROM `member`"));
+			is("SELECT * FROM `member` LIMIT 1"));
 		assertThat(this.orm.single(Member.class).forUpdate().buildQuery()
 			.getSQL(),
-			is("SELECT * FROM `member` FOR UPDATE"));
+			is("SELECT * FROM `member` LIMIT 1 FOR UPDATE"));
 	}
 
 	@Test
 	public void testOrderBy() throws SQLException, RichSQLException {
 		assertThat(this.orm.single(Member.class)
 			.orderBy("id ASC").buildQuery().getSQL(),
-			is("SELECT * FROM `member` ORDER BY id ASC"));
+			is("SELECT * FROM `member` ORDER BY id ASC LIMIT 1"));
 		assertThat(this.orm.single(Member.class)
 			.orderBy("id DESC").buildQuery().getSQL(),
-			is("SELECT * FROM `member` ORDER BY id DESC"));
+			is("SELECT * FROM `member` ORDER BY id DESC LIMIT 1"));
 	}
 
 	@Test
 	public void testLimit() {
 		assertThat(this.orm.search(Member.class)
+			.limit(10).buildQuery().getSQL(),
+			is("SELECT * FROM `member` LIMIT 10"));
+
+		// limit(10) override limit(1) (default for single())
+		assertThat(this.orm.single(Member.class)
 			.limit(10).buildQuery().getSQL(),
 			is("SELECT * FROM `member` LIMIT 10"));
 	}


### PR DESCRIPTION
This patch forces TinyORM to append `LIMIT 1` clause to SQL generated by `single()`.
(If `.limit(x)` is specified explicitly, 'x' will override that bahavior; but I cannot guess reasonable use-cases :smile: )

Purpose:
We sometimes write careless code that produces inefficient SQL, for example 'SELECT * FROM t',where the table 't' has 20 billion records even if we only want one record.  This patch introduces fail-safe mechanism into TinyORM.

Other ORM implementations that care about `LIMIT 1`:
* Rails's find()
* Teng's single() (https://metacpan.org/source/SATOH/Teng-0.28/lib/Teng.pm#L574)