### PR TITLE
Make it possible to specify connection that is used by each method

### DIFF
--- a/tinyorm/src/main/java/me/geso/tinyorm/AbstractSelectStatement.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/AbstractSelectStatement.java
@@ -19,6 +19,7 @@ abstract class AbstractSelectStatement<T, Impl> {
 	private Long limit;
 	private Long offset;
 	private boolean forUpdate = false;
+	private boolean forceWriteConnection = false;
 
 	AbstractSelectStatement(Connection connection, String tableName) {
 		this.tableName = tableName;
@@ -61,6 +62,12 @@ abstract class AbstractSelectStatement<T, Impl> {
 		return (Impl)this;
 	}
 
+	@SuppressWarnings("unchecked")
+	public Impl forceWriteConnection() {
+		forceWriteConnection = true;
+		return (Impl)this;
+	}
+
 	protected Query buildQuery() {
 		QueryBuilder builder = new QueryBuilder(this.identifierQuoteString)
 			.appendQuery("SELECT * FROM ")
@@ -93,5 +100,9 @@ abstract class AbstractSelectStatement<T, Impl> {
 
 	protected boolean isForUpdate() {
 		return forUpdate;
+	}
+
+	protected boolean isForceWriteConnection() {
+		return forceWriteConnection;
 	}
 }

--- a/tinyorm/src/main/java/me/geso/tinyorm/BeanSelectStatement.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/BeanSelectStatement.java
@@ -31,7 +31,8 @@ public class BeanSelectStatement<T extends Row<?>> extends
 
 		final String sql = query.getSQL();
 		final List<Object> params = query.getParameters();
-		try (final PreparedStatement ps = isForUpdate() ? orm.prepareStatement(sql) : orm.prepareStatementForRead(sql)) {
+		try (final PreparedStatement ps = isForUpdate() || isForceWriteConnection() ? orm.prepareStatement(sql) :
+				orm.prepareStatementForRead(sql)) {
 			JDBCUtils.fillPreparedStatementParams(ps, params);
 			try (final ResultSet rs = ps.executeQuery()) {
 				List<String> columnLabels = TinyORM.getColumnLabels(rs);

--- a/tinyorm/src/main/java/me/geso/tinyorm/ListSelectStatement.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/ListSelectStatement.java
@@ -31,7 +31,8 @@ public class ListSelectStatement<T extends Row<?>> extends
 
 		final String sql = query.getSQL();
 		final List<Object> params = query.getParameters();
-		try (final PreparedStatement ps = isForUpdate() ? orm.prepareStatement(sql) : orm.prepareStatementForRead(sql)) {
+		try (final PreparedStatement ps = isForUpdate() || isForceWriteConnection() ? orm.prepareStatement(sql) :
+				orm.prepareStatementForRead(sql)) {
 			JDBCUtils.fillPreparedStatementParams(ps, params);
 			try (final ResultSet rs = ps.executeQuery()) {
 				List<T> rows = new ArrayList<>();

--- a/tinyorm/src/main/java/me/geso/tinyorm/PaginatedSelectStatement.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/PaginatedSelectStatement.java
@@ -31,7 +31,8 @@ public class PaginatedSelectStatement<T extends Row<?>> extends
 
 		final String sql = query.getSQL();
 		final List<Object> params = query.getParameters();
-		try (final PreparedStatement ps = isForUpdate() ? orm.prepareStatement(sql) : orm.prepareStatementForRead(sql)) {
+		try (final PreparedStatement ps = isForUpdate() || isForceWriteConnection() ? orm.prepareStatement(sql) :
+				orm.prepareStatementForRead(sql)) {
 			JDBCUtils.fillPreparedStatementParams(ps, params);
 			try (final ResultSet rs = ps.executeQuery()) {
 				List<T> rows = orm.mapRowListFromResultSet(klass, rs);

--- a/tinyorm/src/main/java/me/geso/tinyorm/Row.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/Row.java
@@ -1,5 +1,6 @@
 package me.geso.tinyorm;
 
+import java.sql.Connection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -30,8 +31,18 @@ public abstract class Row<T extends Row<?>> {
 	 */
 	@SuppressWarnings("unchecked")
 	public Optional<T> refetch() {
+		return refetch(orm.getReadConnection());
+	}
+
+	/**
+	 * Fetch the latest row data from database.
+	 *
+	 * @return Fetched object. It may return empty response if other connection deleted the row.
+	 */
+	@SuppressWarnings("unchecked")
+	public Optional<T> refetch(final Connection connection) {
 		checkORM();
-		return this.orm.refetch((T)this);
+		return orm.refetch((T)this, connection);
 	}
 
 	/**

--- a/tinyorm/src/test/java/me/geso/tinyorm/BasicRowTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/BasicRowTest.java
@@ -54,6 +54,20 @@ public class BasicRowTest extends TestBase {
 	}
 
 	@Test
+	public void testRefetchWithSpecifiedConnection() throws Exception {
+		X x = orm.insert(X.class).value("name", "John").executeSelect();
+		assertEquals(x.getName(), "John");
+		assertEquals(x.getId(), 1);
+		assertEquals("inserted", x.getY());
+
+		orm.createUpdateStatement(x).set("name", "Taro").execute();
+		X refetched = orm.refetch(x, orm.getConnection()).get();
+		assertEquals("Taro", refetched.getName());
+		assertEquals(1, refetched.getId());
+		assertEquals("updated", refetched.getY());
+	}
+
+	@Test
 	public void testCreateUpdateStatementWithInheritance() throws SQLException,
 			RichSQLException {
 		Y y = orm.insert(Y.class)


### PR DESCRIPTION
1. Support `forceWriteConnection` on SelectStatement to force to use write (master) connection.
2. Make it possible to pass connection to method (`searchBySQL`,  `searchBySQLWithPager` and etc.)