### PR TITLE
Fix property name in table meta class

### DIFF
--- a/tinyorm/src/main/java/me/geso/tinyorm/TableMeta.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/TableMeta.java
@@ -124,7 +124,8 @@ class TableMeta<RowType extends Row<?>> {
 		}
 		Map<String, Field> fieldMap = new HashMap<>();
 		for (Field field : fields) {
-			fieldMap.put(field.getName(), field);
+			String capitalizedFieldName = field.getName().substring(0, 1).toUpperCase() + field.getName().substring(1);
+			fieldMap.put(Introspector.decapitalize(capitalizedFieldName), field);
 		}
 		for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
 			String name = propertyDescriptor.getName();

--- a/tinyorm/src/main/java/me/geso/tinyorm/TableMeta.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/TableMeta.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -124,7 +125,9 @@ class TableMeta<RowType extends Row<?>> {
 		}
 		Map<String, Field> fieldMap = new HashMap<>();
 		for (Field field : fields) {
-			String capitalizedFieldName = field.getName().substring(0, 1).toUpperCase() + field.getName().substring(1);
+			String fieldName = field.getName();
+			String capitalizedFieldName = fieldName.substring(0, 1).toUpperCase(Locale.ENGLISH)
+										  + (fieldName.length() > 0 ? fieldName.substring(1) : "");
 			fieldMap.put(Introspector.decapitalize(capitalizedFieldName), field);
 		}
 		for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {

--- a/tinyorm/src/test/java/me/geso/tinyorm/TableMetaTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/TableMetaTest.java
@@ -40,6 +40,7 @@ public class TableMetaTest extends TestBase {
 		TableMeta<?> tableMeta = orm
 			.getTableMeta(Member.class);
 		assertTrue(tableMeta.hasColumn("id"));
+		assertTrue(tableMeta.hasColumn("q_no"));
 		assertFalse(tableMeta.hasColumn("unknown"));
 	}
 
@@ -66,6 +67,8 @@ public class TableMetaTest extends TestBase {
 		private String name;
 		@Column("e_mail")
 		private String email;
+		@Column("q_no")
+		private String qNo;
 
 		@CreatedTimestampColumn
 		private long createdOn;

--- a/tinyorm/src/test/java/me/geso/tinyorm/TableMetaTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/TableMetaTest.java
@@ -55,7 +55,7 @@ public class TableMetaTest extends TestBase {
 		final Field parameterNamesField = rowBuilder.getClass().getDeclaredField("parameterNames");
 		parameterNamesField.setAccessible(true);
 		final String[] parameterNames = (String[])parameterNamesField.get(rowBuilder);
-		assertThat(parameterNames, is(new String[]{"id", "name", "e_mail", "q_no", "url", "createdOn", "updatedOn"}));
+		assertThat(parameterNames, is(new String[]{"id", "name", "e_mail", "q_no", "url", "a", "createdOn", "updatedOn"}));
 	}
 
 	@Table("member")
@@ -72,6 +72,8 @@ public class TableMetaTest extends TestBase {
 		private String qNo;
 		@Column("url")
 		private String URL;
+		@Column
+		private String a;
 
 		@CreatedTimestampColumn
 		private long createdOn;

--- a/tinyorm/src/test/java/me/geso/tinyorm/TableMetaTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/TableMetaTest.java
@@ -41,6 +41,7 @@ public class TableMetaTest extends TestBase {
 			.getTableMeta(Member.class);
 		assertTrue(tableMeta.hasColumn("id"));
 		assertTrue(tableMeta.hasColumn("q_no"));
+		assertTrue(tableMeta.hasColumn("url"));
 		assertFalse(tableMeta.hasColumn("unknown"));
 	}
 
@@ -54,7 +55,7 @@ public class TableMetaTest extends TestBase {
 		final Field parameterNamesField = rowBuilder.getClass().getDeclaredField("parameterNames");
 		parameterNamesField.setAccessible(true);
 		final String[] parameterNames = (String[])parameterNamesField.get(rowBuilder);
-		assertThat(parameterNames, is(new String[]{"id", "name", "e_mail", "createdOn", "updatedOn"}));
+		assertThat(parameterNames, is(new String[]{"id", "name", "e_mail", "q_no", "url", "createdOn", "updatedOn"}));
 	}
 
 	@Table("member")
@@ -69,6 +70,8 @@ public class TableMetaTest extends TestBase {
 		private String email;
 		@Column("q_no")
 		private String qNo;
+		@Column("url")
+		private String URL;
 
 		@CreatedTimestampColumn
 		private long createdOn;

--- a/tinyorm/src/test/java/me/geso/tinyorm/annotations/NamedColumnTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/annotations/NamedColumnTest.java
@@ -20,17 +20,20 @@ public class NamedColumnTest extends TestBase {
 			"id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT",
 			"member_name VARCHAR(255) NOT NULL",
 			"entry_name VARCHAR(255) NOT NULL",
-			"q_no VARCHAR(255) NOT NULL");
+			"q_no VARCHAR(255) NOT NULL",
+			"url VARCHAR(255) NOT NULL");
 
 		X created = orm.insert(X.class)
 			.value("member_name", "John")
 			.value("entry_name", "Foo")
 			.value("q_no", "qNo")
+			.value("url", "http://example.com")
 			.executeSelect();
 
 		assertEquals("John", created.getMemberName());
 		assertEquals("Foo", created.getEntryName());
 		assertEquals("qNo", created.getQNo());
+		assertEquals("http://example.com", created.getURL());
 	}
 
 	@Test
@@ -62,6 +65,9 @@ public class NamedColumnTest extends TestBase {
 
 		@Column("q_no")
 		private String qNo;
+
+		@Column("url")
+		private String URL;
 	}
 
 	@Getter

--- a/tinyorm/src/test/java/me/geso/tinyorm/annotations/NamedColumnTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/annotations/NamedColumnTest.java
@@ -3,15 +3,15 @@ package me.geso.tinyorm.annotations;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.sql.SQLException;
+
+import org.junit.Test;
+
 import lombok.Getter;
 import lombok.Setter;
 import me.geso.jdbcutils.RichSQLException;
 import me.geso.tinyorm.Row;
 import me.geso.tinyorm.TestBase;
-
-import org.junit.Test;
-
-import java.sql.SQLException;
 
 public class NamedColumnTest extends TestBase {
 	@Test
@@ -19,15 +19,18 @@ public class NamedColumnTest extends TestBase {
 		createTable("x",
 			"id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT",
 			"member_name VARCHAR(255) NOT NULL",
-			"entry_name VARCHAR(255) NOT NULL");
+			"entry_name VARCHAR(255) NOT NULL",
+			"q_no VARCHAR(255) NOT NULL");
 
 		X created = orm.insert(X.class)
 			.value("member_name", "John")
 			.value("entry_name", "Foo")
+			.value("q_no", "qNo")
 			.executeSelect();
 
 		assertEquals("John", created.getMemberName());
 		assertEquals("Foo", created.getEntryName());
+		assertEquals("qNo", created.getQNo());
 	}
 
 	@Test
@@ -56,6 +59,9 @@ public class NamedColumnTest extends TestBase {
 
 		@Column("entry_name")
 		private String entryName;
+
+		@Column("q_no")
+		private String qNo;
 	}
 
 	@Getter


### PR DESCRIPTION
If property name is `qNo` in Row class,  `rowClass.getDeclaredFields()` returns [{name: "qNo"}].

https://github.com/tokuhirom/tinyorm/blob/187e05c24b2dddc6aec33c309db7ed784f494dba/tinyorm/src/main/java/me/geso/tinyorm/TableMeta.java#L119

However, `propertyDescriptor.getName()` returns `QNo`.

https://github.com/tokuhirom/tinyorm/blob/187e05c24b2dddc6aec33c309db7ed784f494dba/tinyorm/src/main/java/me/geso/tinyorm/TableMeta.java#L130

This reason is blow link.
ref : http://stackoverflow.com/questions/40822397/why-does-propertydescriptor-return-a-property-name-with-uppercase-as-first-chara

So, I want to solve this problem by using `Introspector.decapitalize()` method