### PR TITLE
Fix insert and update by bean

### DIFF
--- a/tinyorm/src/main/java/me/geso/tinyorm/InsertStatement.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/InsertStatement.java
@@ -87,15 +87,16 @@ public class InsertStatement<T extends Row<?>> {
 	 */
 	public InsertStatement<T> valueByBean(Object valueBean) {
 		try {
-			BeanInfo beanInfo = Introspector.getBeanInfo(valueBean.getClass(),
-				Object.class);
-			for (PropertyDescriptor propertyDescriptor : beanInfo
-				.getPropertyDescriptors()) {
+			BeanInfo beanInfo = Introspector.getBeanInfo(valueBean.getClass(), Object.class);
+			for (PropertyDescriptor propertyDescriptor : beanInfo.getPropertyDescriptors()) {
 				Method readMethod = propertyDescriptor.getReadMethod();
-				if (readMethod != null) {
-					Object value = readMethod.invoke(valueBean);
-					this.value(propertyDescriptor.getName(), value);
+				if (readMethod == null) {
+					continue;
 				}
+
+				Object value = readMethod.invoke(valueBean);
+				tableMeta.getColumnName(propertyDescriptor)
+					.ifPresent(columnName -> this.value(columnName, value));
 			}
 			return this;
 		} catch (IntrospectionException | IllegalAccessException

--- a/tinyorm/src/main/java/me/geso/tinyorm/TableMeta.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/TableMeta.java
@@ -556,6 +556,20 @@ class TableMeta<RowType extends Row<?>> {
 		return propertyDescriptorMap.containsKey(columnName);
 	}
 
+	public Optional<String> getColumnName(PropertyDescriptor beanPropertyDescriptor) {
+		return propertyDescriptorMap
+			.entrySet()
+			.stream()
+			.filter(entry -> {
+				PropertyDescriptor propertyDescriptor = entry.getValue();
+				return propertyDescriptor.getPropertyType().isAssignableFrom(beanPropertyDescriptor.getPropertyType())
+			   		&& propertyDescriptor.getReadMethod().getName().equals(beanPropertyDescriptor.getReadMethod().getName())
+					&& propertyDescriptor.getWriteMethod().getName().equals(beanPropertyDescriptor.getWriteMethod().getName());
+			})
+			.findFirst()
+			.map(Map.Entry::getKey);
+	}
+
 	RowType createRowFromResultSet(
 			final Class<RowType> klass,
 			final ResultSet rs,


### PR DESCRIPTION
If use `@Column("column_name")` annotation in Row class, failed to insert or update by bean.
(`InsertStatement#valueByBean` or `UpdateRowStatement#setBean`) 

This p-r is fix this bug.