### PR TITLE
Get new connection after close method called

### DIFF
--- a/tinyorm/src/main/java/me/geso/tinyorm/TinyORM.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/TinyORM.java
@@ -69,56 +69,58 @@ public class TinyORM implements Closeable {
 	}
 
 	public Connection getConnection() {
-		if (connection == null) {
-			if (connectionProvider == null) {
-				throw new RuntimeException("Connection provider is null");
-			}
-
-			synchronized (this) { // For multi-threads, protect from duplicated borrowing
-				if (connection == null) {
-					connection = connectionProvider.get();
-					transactionManager = new TransactionManager(connection);
+		try {
+			if (connection == null || connection.isClosed()) {
+				if (connectionProvider == null) {
+					throw new RuntimeException("Connection provider is null");
 				}
-				// otherwise, connection has been borrowed by another thread
+
+				synchronized (this) { // For multi-threads, protect from duplicated borrowing
+					if (connection == null || connection.isClosed()) {
+						connection = connectionProvider.get();
+						transactionManager = new TransactionManager(connection);
+					}
+					// otherwise, connection has been borrowed by another thread
+				}
 			}
+		} catch (SQLException e) {
+			throw new RuntimeException("Failed to get connection", e);
 		}
 		return connection;
 	}
 
 	public Connection getReadConnection() {
 		try {
-			if (connection != null && !connection.getAutoCommit()) {
+			if (connection != null && !connection.isClosed() && !connection.getAutoCommit()) {
 				// If transaction has been started, return the connection which has taken the transaction.
 				return connection;
 			}
 		} catch (SQLException e) {
-			try {
-				if (!connection.isClosed()) {
-					// Not closed connection, DB access error is occured
-					throw new RuntimeException("Failed to get the mode of auto commit", e);
-				}
-			} catch (SQLException e1) {
-				throw new RuntimeException("Failed to get the mode of auto commit", e1);
-			}
+			// DB access error is occured
+			throw new RuntimeException("Failed to get the mode of auto commit", e);
 		}
 
-		if (readConnection == null) {
-			if (readConnectionProvider == null) {
-				if (connectionProvider != null) {
-					// For lazily borrowing with single connection
-					readConnection = getConnection(); // use the same connection as write/read
-					return readConnection;
+		try {
+			if (readConnection == null || readConnection.isClosed()) {
+				if (readConnectionProvider == null) {
+					if (connectionProvider != null) {
+						// For lazily borrowing with single connection
+						readConnection = getConnection(); // use the same connection as write/read
+						return readConnection;
+					}
+
+					throw new RuntimeException("Read connection provider is null");
 				}
 
-				throw new RuntimeException("Read connection provider is null");
-			}
-
-			synchronized (this) { // For multi-threads, protect from duplicated borrowing
-				if (readConnection == null) {
-					readConnection = readConnectionProvider.get();
+				synchronized (this) { // For multi-threads, protect from duplicated borrowing
+					if (readConnection == null || readConnection.isClosed()) {
+						readConnection = readConnectionProvider.get();
+					}
+					// otherwise, connection has been borrowed by another thread
 				}
-				// otherwise, connection has been borrowed by another thread
 			}
+		} catch (SQLException e) {
+			throw new RuntimeException("Failed to get connection", e);
 		}
 		return readConnection;
 	}


### PR DESCRIPTION
### Overview
Renew connection after close() method called, because once close() method called, closed connection instances remains in TinyORM instance, so if you would call getConnection() or getReadConnection() again, you would get closed connection instances.
This problem is troublesome for web application with connection pool, which returns connections while it need not to interact with DB.