### PR TITLE
Get new connection after close method called

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
+dist: trusty
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_install:
   - mysql -e "CREATE DATABASE IF NOT EXISTS test;" -uroot
   - mysql -e "CREATE USER 'read_only'@'localhost';" -uroot

--- a/tinyorm/src/main/java/me/geso/tinyorm/TinyORM.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/TinyORM.java
@@ -871,11 +871,13 @@ public class TinyORM implements Closeable {
 		try {
 			if (connection != null) {
 				connection.close();
+				connection = null;
 			}
 
 			if (readConnection != null) {
 				if (!readConnection.isClosed()) {
 					readConnection.close();
+					readConnection = null;
 				}
 			}
 		} catch (SQLException e) {


### PR DESCRIPTION
### Overview
Renew connection after close() method called, because once close() method called, closed connection instances remains in TinyORM instance, so if you would call getConnection() or getReadConnection() again, you would get closed connection instances.
This problem is troublesome for web application with connection pool, which returns connections while it need not to interact with DB.