### PR TITLE
Revert ListSelectStatement#executeWithPagination

### DIFF
--- a/tinyorm/src/main/java/me/geso/tinyorm/ListSelectStatement.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/ListSelectStatement.java
@@ -5,6 +5,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import me.geso.jdbcutils.JDBCUtils;
@@ -41,6 +42,13 @@ public class ListSelectStatement<T extends Row<?>> extends
             }
 		} catch (final SQLException ex) {
 			throw new UncheckedRichSQLException(ex, sql, params);
+		}
+	}
+
+	public Paginated<T> executeWithPagination(long entriesPerPage) {
+		try (Stream<T> stream = executeStream()) {
+			return new Paginated<>(stream.limit(entriesPerPage + 1).collect(Collectors.toList()),
+								   entriesPerPage);
 		}
 	}
 

--- a/tinyorm/src/test/java/me/geso/tinyorm/ListSelectStatementTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/ListSelectStatementTest.java
@@ -1,7 +1,7 @@
 package me.geso.tinyorm;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -21,6 +21,41 @@ public class ListSelectStatementTest extends TestBase {
         createTable("member",
                     "id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY",
                     "name VARCHAR(255) NOT NULL");
+    }
+
+    @Test
+    public void testExecuteWithPagination() {
+        // empty result
+        {
+            Paginated<Member> list = orm.search(Member.class).orderBy("id DESC").executeWithPagination(1);
+            assertThat(list.getRows().size(), is(0));
+            assertThat(list.getEntriesPerPage(), is(1L));
+            assertThat(list.getHasNextPage(), is(false));
+        }
+        for (int i = 0; i<3; i++) {
+            orm.insert(Member.class).value("name", "name").execute();
+        }
+        // first page
+        {
+            Paginated<Member> list = orm.search(Member.class).orderBy("id DESC").executeWithPagination(1);
+            assertThat(list.getRows().size(), is(1));
+            assertThat(list.getEntriesPerPage(), is(1L));
+            assertThat(list.getHasNextPage(), is(true));
+        }
+        // last page
+        {
+            Paginated<Member> list = orm.search(Member.class).orderBy("id DESC").executeWithPagination(3);
+            assertThat(list.getRows().size(), is(3));
+            assertThat(list.getEntriesPerPage(), is(3L));
+            assertThat(list.getHasNextPage(), is(false));
+        }
+        // last page (less than entries per page)
+        {
+            Paginated<Member> list = orm.search(Member.class).orderBy("id DESC").executeWithPagination(4);
+            assertThat(list.getRows().size(), is(3));
+            assertThat(list.getEntriesPerPage(), is(4L));
+            assertThat(list.getHasNextPage(), is(false));
+        }
     }
 
     @Test


### PR DESCRIPTION
### Overview
- Add ListSelectStatement#executeWithPagination (which was deleted in https://github.com/tokuhirom/tinyorm/pull/44 ) for backward comaptibility
- Use executeStream method in executeWithPagination