### PR TITLE
[Bug] Fix SQL syntax error when using offset

### DIFF
--- a/tinyorm/src/main/java/me/geso/tinyorm/ListSelectStatement.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/ListSelectStatement.java
@@ -46,8 +46,8 @@ public class ListSelectStatement<T extends Row<?>> extends
 	}
 
 	public Paginated<T> executeWithPagination(long entriesPerPage) {
-		try (Stream<T> stream = executeStream()) {
-			return new Paginated<>(stream.limit(entriesPerPage + 1).collect(Collectors.toList()),
+		try (Stream<T> stream = this.limit(entriesPerPage + 1).executeStream()) {
+			return new Paginated<>(stream.collect(Collectors.toList()),
 								   entriesPerPage);
 		}
 	}

--- a/tinyorm/src/test/java/me/geso/tinyorm/ListSelectStatementTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/ListSelectStatementTest.java
@@ -3,6 +3,8 @@ package me.geso.tinyorm;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -32,8 +34,9 @@ public class ListSelectStatementTest extends TestBase {
             assertThat(list.getEntriesPerPage(), is(1L));
             assertThat(list.getHasNextPage(), is(false));
         }
+        final List<Member> members = new ArrayList<>();
         for (int i = 0; i<3; i++) {
-            orm.insert(Member.class).value("name", "name").execute();
+            members.add(orm.insert(Member.class).value("name", "name").executeSelect());
         }
         // first page
         {
@@ -55,6 +58,12 @@ public class ListSelectStatementTest extends TestBase {
             assertThat(list.getRows().size(), is(3));
             assertThat(list.getEntriesPerPage(), is(4L));
             assertThat(list.getHasNextPage(), is(false));
+        }
+        // with offset
+        {
+            Paginated<Member> list = orm.search(Member.class).orderBy("id").offset(1).executeWithPagination(1);
+            assertThat(list.getRows().size(), is(1));
+            assertThat(list.getRows().get(0).getId(), is(members.get(1).getId()));
         }
     }
 


### PR DESCRIPTION
### Overview
Fix bug when you call executeWithPagination() after calling offset().

```
[main] ERROR jdbc.audit - 2. PreparedStatement.executeQuery() SELECT * FROM `member` ORDER BY id OFFSET 1 

java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'OFFSET 1' at line 1
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:1003)
	at net.sf.log4jdbc.PreparedStatementSpy.executeQuery(PreparedStatementSpy.java:734)
	at me.geso.tinyorm.ListSelectStatement.executeStream(ListSelectStatement.java:72)
	at me.geso.tinyorm.ListSelectStatement.executeWithPagination(ListSelectStatement.java:49)
	at me.geso.tinyorm.ListSelectStatementTest.testExecuteWithPagination(ListSelectStatementTest.java:64)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)
[main] ERROR jdbc.sqlonly - 2. PreparedStatement.executeQuery() SELECT * FROM `member` ORDER BY id OFFSET 1 
```