### PR TITLE
Add method: hasActiveTransaction

### DIFF
--- a/tinyorm/src/main/java/me/geso/tinyorm/TinyORM.java
+++ b/tinyorm/src/main/java/me/geso/tinyorm/TinyORM.java
@@ -868,6 +868,9 @@ public class TinyORM implements Closeable {
 	public void close() {
 		try {
 			synchronized (this) {
+				if (hasActiveTransaction()) {
+					return;
+				}
 				if (connection != null) {
 					if (!connection.isClosed()) {
 						connection.close();
@@ -955,5 +958,12 @@ public class TinyORM implements Closeable {
 	 */
 	public void transactionRollback() throws SQLException {
 		getTransactionManager().txnRollback();
+	}
+
+	/**
+	 * Check if any active transaction exists.
+	 */
+	public boolean hasActiveTransaction() {
+		return transactionManager != null && !transactionManager.getActiveTransactions().isEmpty();
 	}
 }

--- a/tinyorm/src/test/java/me/geso/tinyorm/TransactionTest.java
+++ b/tinyorm/src/test/java/me/geso/tinyorm/TransactionTest.java
@@ -1,6 +1,8 @@
 package me.geso.tinyorm;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import net.moznion.db.transaction.manager.TransactionScope;
 
@@ -72,6 +74,16 @@ public class TransactionTest extends TestBase {
 		}
 		Optional<X> row = orm.single(X.class).where("a=?", "hoge").execute();
 		assertEquals(row.isPresent(), false);
+	}
+
+	@Test
+	public void testHasActiveTransaction() throws SQLException {
+		assertFalse(orm.hasActiveTransaction());
+		try (TransactionScope txn = orm.createTransactionScope()) {
+			assertTrue(orm.hasActiveTransaction());
+			orm.transactionCommit();
+		}
+		assertFalse(orm.hasActiveTransaction());
 	}
 
 	@Table("x")


### PR DESCRIPTION
### Overview
- Add method to check if any active transaction exists without calling TinyORM#getTransactionManager() (because if you call this method, it will acquire a write connection at the same time)